### PR TITLE
#51 Logic for showing date in date seperator

### DIFF
--- a/lib/helpers/date_helper.dart
+++ b/lib/helpers/date_helper.dart
@@ -81,7 +81,7 @@ String translateEnglishDayNameToNorwegianString(String day) {
     case 'Sunday':
       return 'Søndag';
   }
-  return '';
+  return day;
 }
 
 String translateEnglishMonthToNorwegianString(String month) {
@@ -90,6 +90,8 @@ String translateEnglishMonthToNorwegianString(String month) {
       return 'Januar';
     case 'February':
       return 'Februar';
+    case 'March':
+      return 'Mars';
     case 'May':
       return 'Mai';
     case 'June':

--- a/lib/helpers/date_helper.dart
+++ b/lib/helpers/date_helper.dart
@@ -6,7 +6,7 @@ String getWeekdayDateMonth(Timestamp timestamp) {
   String weekday = getFullDayFromTimestamp(timestamp);
   String date = getDayNumberFromTimestamp(timestamp);
   String month = getMonthFromTimestamp(timestamp);
-  return convertToWeekdayDateMonthFormat(weekday, date, month);
+  return weekday + " " + date + ". " + month;
 }
 
 String getDayFromTimestamp(Timestamp timestamp) {
@@ -102,9 +102,4 @@ String translateEnglishMonthToNorwegianString(String month) {
       return 'Desember';
   }
   return month;
-}
-
-String convertToWeekdayDateMonthFormat(
-    String weekday, String date, String month) {
-  return weekday + " " + date + ". " + month;
 }

--- a/lib/helpers/date_helper.dart
+++ b/lib/helpers/date_helper.dart
@@ -31,7 +31,8 @@ String getDayNumberFromTimestamp(Timestamp timestamp) {
 String getMonthFromTimestamp(Timestamp timestamp) {
   var ts = convertStamp(timestamp);
   var formatter = new DateFormat('MMMM');
-  return translateEnglishMonthToNorwegianString(formatter.format(ts).toString());
+  return translateEnglishMonthToNorwegianString(
+      formatter.format(ts).toString());
 }
 
 String getNorwegianWeekDayName(String weekday) {
@@ -103,6 +104,7 @@ String translateEnglishMonthToNorwegianString(String month) {
   return month;
 }
 
-String convertToWeekdayDateMonthFormat(String weekday, String date, String month) {
+String convertToWeekdayDateMonthFormat(
+    String weekday, String date, String month) {
   return weekday + " " + date + ". " + month;
 }

--- a/lib/helpers/date_helper.dart
+++ b/lib/helpers/date_helper.dart
@@ -6,7 +6,7 @@ String getWeekdayDateMonth(Timestamp timestamp) {
   String weekday = getFullDayFromTimestamp(timestamp);
   String date = getDayNumberFromTimestamp(timestamp);
   String month = getMonthFromTimestamp(timestamp);
-  return weekday + " " + date + ". " + month;
+  return "$weekday $date. $month";
 }
 
 String getDayFromTimestamp(Timestamp timestamp) {

--- a/lib/helpers/date_helper.dart
+++ b/lib/helpers/date_helper.dart
@@ -2,6 +2,13 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:intl/intl.dart';
 import 'convertTimeStamp_helper.dart';
 
+String getWeekdayDateMonth(Timestamp timestamp) {
+  String weekday = getFullDayFromTimestamp(timestamp);
+  String date = getDayNumberFromTimestamp(timestamp);
+  String month = getMonthFromTimestamp(timestamp);
+  return convertToWeekdayDateMonthFormat(weekday, date, month);
+}
+
 String getDayFromTimestamp(Timestamp timestamp) {
   var ts = convertStamp(timestamp);
   var formatter = new DateFormat('E');
@@ -19,6 +26,12 @@ String getDayNumberFromTimestamp(Timestamp timestamp) {
   var ts = convertStamp(timestamp);
   var formatter = new DateFormat('d');
   return formatter.format(ts).toString();
+}
+
+String getMonthFromTimestamp(Timestamp timestamp) {
+  var ts = convertStamp(timestamp);
+  var formatter = new DateFormat('MMMM');
+  return translateEnglishMonthToNorwegianString(formatter.format(ts).toString());
 }
 
 String getNorwegianWeekDayName(String weekday) {
@@ -68,4 +81,28 @@ String translateEnglishDayNameToNorwegianString(String day) {
       return 'Søndag';
   }
   return '';
+}
+
+String translateEnglishMonthToNorwegianString(String month) {
+  switch (month) {
+    case 'January':
+      return 'Januar';
+    case 'February':
+      return 'Februar';
+    case 'May':
+      return 'Mai';
+    case 'June':
+      return 'Juni';
+    case 'July':
+      return 'Juli';
+    case 'October':
+      return 'October';
+    case 'December':
+      return 'Desember';
+  }
+  return month;
+}
+
+String convertToWeekdayDateMonthFormat(String weekday, String date, String month) {
+  return weekday + " " + date + ". " + month;
 }

--- a/lib/helpers/date_helper.dart
+++ b/lib/helpers/date_helper.dart
@@ -99,7 +99,7 @@ String translateEnglishMonthToNorwegianString(String month) {
     case 'July':
       return 'Juli';
     case 'October':
-      return 'October';
+      return 'Oktober';
     case 'December':
       return 'Desember';
   }

--- a/lib/pages/ProgramPage.dart
+++ b/lib/pages/ProgramPage.dart
@@ -42,7 +42,7 @@ class _ProgramPageState extends State<ProgramPage> {
 
   Widget _buildProgramListItem(
       BuildContext context, DocumentSnapshot document, shouldShowNewDayLabel) {
-    String dayName = getFullDayFromTimestamp(document["startTime"]);
+    String dayName = getWeekdayDateMonth(document["startTime"]);
     return (Column(
       children: <Widget>[
         if (shouldShowNewDayLabel)


### PR DESCRIPTION
It now shows "Tirsdag 9. Juli" instead of "Tirsdag" in the day separator on the program page.