### PR TITLE
Further styling and fields shoown for contentViewerPage

### DIFF
--- a/lib/pages/ContentViewerPage.dart
+++ b/lib/pages/ContentViewerPage.dart
@@ -5,6 +5,8 @@ import 'package:oase/styles.dart';
 import 'package:oase/widgets/molecules/KokaButton.dart';
 import 'package:oase/widgets/molecules/fullScreenImage.dart';
 import 'package:oase/widgets/organisms/KokaCard.dart';
+import 'package:oase/widgets/organisms/KokaCardEvent.dart';
+import 'package:oase/widgets/organisms/TimeBox.dart';
 
 class ContentViewerPage extends StatelessWidget {
   ContentViewerPage(this.document);
@@ -13,6 +15,7 @@ class ContentViewerPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    print(document.documentID);
     return Material(
       child: Scaffold(
         appBar: AppBar(
@@ -25,23 +28,57 @@ class ContentViewerPage extends StatelessWidget {
               padding: const EdgeInsets.all(8.0),
               child: ListView(
                 children: <Widget>[
+                  buildKokaCardEvent(),
                   img(context),
-                  KokaCard(
-                    document: document,
-                    padding: EdgeInsets.only(
-                      left: 10,
-                      right: 10,
-                    ),
-                  ),
-                  if (_exists('url'))
-                    KokaButton(
-                      url: document['url'],
-                    ),
+                  buildKokaCard(),
+                  buildKokaButton(),
+                  buildTimeBox(),
                 ],
               )),
         ),
       ),
     );
+  }
+
+  Widget buildTimeBox() {
+    if (_exists('startTime')) {
+      return TimeBox(
+        document: document,
+      );
+    }
+    return SizedBox.shrink();
+  }
+
+  Widget buildKokaButton() {
+    if (_exists('url')) {
+      return KokaButton(
+        url: document['url'],
+      );
+    }
+    return SizedBox.shrink();
+  }
+
+  Widget buildKokaCard() {
+    if (_exists('content')) {
+      return KokaCard(
+        document: document,
+        padding: EdgeInsets.only(
+          left: 10,
+          right: 10,
+        ),
+      );
+    }
+    return SizedBox.shrink();
+  }
+
+  Widget buildKokaCardEvent() {
+    if (_exists('startTime')) {
+      return KokaCardEvent(
+        document: document,
+        short: false,
+      );
+    }
+    return SizedBox.shrink();
   }
 
   /// Checks if the document have a field

--- a/lib/pages/ProgramPage.dart
+++ b/lib/pages/ProgramPage.dart
@@ -55,6 +55,7 @@ class _ProgramPageState extends State<ProgramPage> {
           ),
         KokaCardEvent(
             document: document,
+            short: true,
             onTapAction: () => Navigator.push(
                   context,
                   MaterialPageRoute(

--- a/lib/styles.dart
+++ b/lib/styles.dart
@@ -83,4 +83,11 @@ abstract class Styles {
 
   static var kokaCardNewsTextTopRight =
       TextStyle(color: Color.fromRGBO(0, 0, 0, 0.4), fontSize: 12);
+
+  static var textTimeBoxDay = TextStyle(
+    fontSize: 12,
+    fontFamily: "Lao Sangam MN",
+    fontWeight: FontWeight.w100,
+    color: Colors.black38,
+  );
 }

--- a/lib/widgets/atoms/TimeWidget.dart
+++ b/lib/widgets/atoms/TimeWidget.dart
@@ -6,10 +6,12 @@ class TimeWidget extends StatelessWidget {
     Key key,
     this.hours,
     this.minutes,
+    this.text,
   }) : super(key: key);
 
   final String hours;
   final String minutes;
+  final String text;
 
   @override
   Widget build(BuildContext context) {
@@ -25,6 +27,9 @@ class TimeWidget extends StatelessWidget {
           "$minutes",
           style: Styles.textEventCardTimeMinutes,
         ),
+        text != null
+            ? Text("$text", style: Styles.textTimeBoxDay)
+            : SizedBox.shrink(),
       ],
     );
   }

--- a/lib/widgets/organisms/KokaCard.dart
+++ b/lib/widgets/organisms/KokaCard.dart
@@ -6,7 +6,6 @@ import 'package:oase/helpers/convertTimeStamp_helper.dart';
 import 'package:oase/helpers/mapCategoryToColor.dart';
 import 'package:oase/styles.dart';
 import 'package:oase/widgets/atoms/ColorStrip.dart';
-import 'package:oase/widgets/atoms/TimeWidget.dart';
 
 class KokaCard extends StatelessWidget {
   const KokaCard({
@@ -77,22 +76,16 @@ class KokaCard extends StatelessWidget {
                         mainAxisAlignment: MainAxisAlignment.start,
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: <Widget>[
-                          if (hours != null && minutes != null)
-                            Container(
-                              margin: EdgeInsets.only(right: 20),
-                              child: TimeWidget(
-                                hours: hours,
-                                minutes: minutes,
-                              ),
-                            ),
                           Flexible(
                             child: Padding(
                               padding: EdgeInsets.all(4),
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: <Widget>[
-                                  _title(title, short),
-                                  _content(content, short),
+                                  hours != null
+                                      ? SizedBox.shrink()
+                                      : _title(title, short),
+                                  _content(content, short)
                                 ],
                               ),
                             ),

--- a/lib/widgets/organisms/KokaCardEvent.dart
+++ b/lib/widgets/organisms/KokaCardEvent.dart
@@ -13,10 +13,12 @@ class KokaCardEvent extends StatelessWidget {
     Key key,
     this.document,
     this.onTapAction,
+    this.short = true,
   }) : super(key: key);
 
   final DocumentSnapshot document;
   final onTapAction;
+  final bool short;
 
   @override
   Widget build(BuildContext context) {
@@ -30,7 +32,7 @@ class KokaCardEvent extends StatelessWidget {
       minutes = formatterMinutes.format(startTime).toString();
     }
     final String title = _exists('title') ? document['title'] : '';
-    final String content = _exists('content') ? document['content'] : '';
+    final String subtitle = _exists('subtitle') ? document['subtitle'] : '';
     final Color colorStart = _exists('category')
         ? mapCategoryToStartColor(document['category'].toString())
         : mapCategoryToStartColor('default');
@@ -65,7 +67,7 @@ class KokaCardEvent extends StatelessWidget {
                 child: InkWell(
                     splashColor: Styles.colorPrimary,
                     child: Container(
-                        height: 60,
+                        height: short ? 60 : null,
                         margin: EdgeInsets.fromLTRB(18, 8, 20, 10),
                         child: Row(
                           children: <Widget>[
@@ -79,15 +81,8 @@ class KokaCardEvent extends StatelessWidget {
                                 child: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: <Widget>[
-                                    Text(title,
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: Styles.textEventCardHeader),
-                                    Text(content,
-                                        overflow: TextOverflow.ellipsis,
-                                        maxLines: 1,
-                                        softWrap: true,
-                                        style: Styles.textEventCardContent),
+                                    buildTitle(title, short),
+                                    buildSubtitle(subtitle, short),
                                   ],
                                 ),
                               ),
@@ -103,11 +98,45 @@ class KokaCardEvent extends StatelessWidget {
     );
   }
 
+  Widget buildTitle(String title, bool short) {
+    if (title == '') {
+      return SizedBox.shrink();
+    }
+    if (short) {
+      return Text(title,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Styles.textEventCardHeader);
+    } else {
+      return Text(title, softWrap: true, style: Styles.textEventCardHeader);
+    }
+  }
+
+  Widget buildSubtitle(String subtitle, bool short) {
+    if (subtitle == null ?? subtitle == '') {
+      return SizedBox.shrink();
+    }
+    if (short) {
+      return Text(formatText(subtitle),
+          overflow: TextOverflow.ellipsis,
+          maxLines: 1,
+          softWrap: true,
+          style: Styles.textEventCardContent);
+    } else {
+      return Text(formatText(subtitle),
+          softWrap: true, style: Styles.textEventCardContent);
+    }
+  }
+
   /// Checks if the document have a field
   /// that matches the provided string.
   /// Returns True if the string does exist,
   /// and False if not.
   _exists(String s) {
     return ((document[s] ?? '') != '');
+  }
+
+  String formatText(String content) {
+    return content.replaceAll("\\n", "\n");
   }
 }

--- a/lib/widgets/organisms/TimeBox.dart
+++ b/lib/widgets/organisms/TimeBox.dart
@@ -1,0 +1,135 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:intl/intl.dart';
+import 'package:oase/helpers/convertTimeStamp_helper.dart';
+import 'package:oase/helpers/date_helper.dart';
+import 'package:oase/styles.dart';
+import 'package:oase/widgets/atoms/TimeWidget.dart';
+
+class TimeBox extends StatelessWidget {
+  const TimeBox({
+    Key key,
+    this.document,
+    this.onTapAction,
+  }) : super(key: key);
+
+  final DocumentSnapshot document;
+  final onTapAction;
+
+  @override
+  Widget build(BuildContext context) {
+    String startHours;
+    String startMinutes;
+    String startDayName;
+    if (_exists('startTime')) {
+      var startTime = convertStamp(document['startTime']);
+      var formatterHours = new DateFormat('HH');
+      var formatterMinutes = new DateFormat('mm');
+      startHours = formatterHours.format(startTime).toString();
+      startMinutes = formatterMinutes.format(startTime).toString();
+      startDayName = getWeekdayDateMonth(document["startTime"]);
+    }
+    String endHours;
+    String endMinutes;
+    String endDayName;
+    if (_exists('endTime')) {
+      var startTime = convertStamp(document['endTime']);
+      var formatterHours = new DateFormat('HH');
+      var formatterMinutes = new DateFormat('mm');
+      endHours = formatterHours.format(startTime).toString();
+      endMinutes = formatterMinutes.format(startTime).toString();
+      endDayName = getWeekdayDateMonth(document["endTime"]) ?? null;
+    }
+    return Padding(
+      padding: const EdgeInsets.all(10),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          Expanded(
+            child: Container(
+              decoration: new BoxDecoration(boxShadow: [
+                new BoxShadow(
+                  color: Styles.colorShadowCardMain,
+                  blurRadius: 10,
+                  offset: Offset(0, 4),
+                ),
+              ]),
+              child: Card(
+                shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(0))),
+                color: Styles.kokaEventCardColorBackground,
+                elevation: 0,
+                margin: EdgeInsets.all(0),
+                child: Container(
+                    margin: EdgeInsets.fromLTRB(18, 8, 20, 10),
+                    child: buildTimeContent(startHours, startMinutes,
+                        startDayName, endHours, endMinutes, endDayName)),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget buildTimeContent(
+      String startHours,
+      String startMinutes,
+      String startDayName,
+      String endHours,
+      String endMinutes,
+      String endDayName) {
+    if (endHours == null) {
+      return TimeWidget(
+        hours: startHours,
+        minutes: startMinutes,
+        text: '$startDayName',
+      );
+    }
+    return Column(
+      children: <Widget>[
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          children: <Widget>[
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.only(left: 18, right: 18),
+                  child: TimeWidget(
+                    hours: startHours,
+                    minutes: startMinutes,
+                    text: '$startDayName',
+                  ),
+                ),
+              ],
+            ),
+            Icon(Icons.arrow_forward),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.only(left: 18, right: 18),
+                  child: TimeWidget(
+                    hours: endHours,
+                    minutes: endMinutes,
+                    text: '$endDayName',
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  /// Checks if the document have a field
+  /// that matches the provided string.
+  /// Returns True if the string does exist,
+  /// and False if not.
+  _exists(String s) {
+    return ((document[s] ?? '') != '');
+  }
+}


### PR DESCRIPTION
- show Start and end time
- show start date and end date
- hide end-date/time if it's not a field
- hide title up in kokaEventCard if there is no startTime, then we show it in the KokaCard (with the content)

Also, some refactoring, but I wrote tired code... so sorry if it's a little untidy...

	modified:   lib/pages/ContentViewerPage.dart
	modified:   lib/pages/ProgramPage.dart
	modified:   lib/styles.dart
	modified:   lib/widgets/atoms/TimeWidget.dart
	modified:   lib/widgets/organisms/KokaCard.dart
	modified:   lib/widgets/organisms/KokaCardEvent.dart
	new file:   lib/widgets/organisms/TimeBox.dart